### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
     - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
 
-    - uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25 # v2.3.0
+    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v2.2.0
+    - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v3.2.0
       with:
         go-version: ${{ env.GO_VERSION }}
         check-latest: true
@@ -42,7 +42,7 @@ jobs:
 
     - uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25 # v2.3.0
 
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
 
     - name: Login to registry
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
         egress-policy: audit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         check-latest: true
+        # Disable the Go build/module cache on this signed-release flow: a
+        # poisoned cache from an earlier lower-trust run could otherwise be
+        # restored into the tag-push release that cosign-signs + publishes.
+        cache: false
 
     - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,10 @@ jobs:
         persist-credentials: false
 
     - name: Login to registry
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        echo ${{ github.token }} | docker login ghcr.io --username=${{ github.repository_owner }} --password-stdin
+        echo "$GH_TOKEN" | docker login ghcr.io --username="$GITHUB_REPOSITORY_OWNER" --password-stdin
 
     - name: Publish/Sign image
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
     - uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25 # v2.3.0
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      with:
+        persist-credentials: false
 
     - name: Login to registry
       run: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
This PR hardens the release workflow (`.github/workflows/release.yml`), surfaced
by static analysis (zizmor). It's a signed-release path (tag push → cosign sign +
`ko` publish, with `id-token`/`packages` write), so the fixes focus on shrinking
that flow's attack surface.

## What this changes

- **`persist-credentials: false` on checkout.** The release job doesn't push
  back to the repo, so the auto-persisted `GITHUB_TOKEN` in `.git/config` is
  unnecessary; drop it.
- **Template-injection fix** in the registry-login step: the `${{ … }}`
  expressions are moved into `env:` and referenced as quoted shell variables,
  so the shell — not the workflow templater — handles them.
- **Disable the Go build/module cache on the release flow** (`cache: false` on
  `actions/setup-go`). `setup-go`'s cache bundles the verified module cache with
  the unverified `~/.cache/go-build`, so a cache poisoned by an earlier
  lower-trust run could be restored into the signed, published image. Releases
  are infrequent — a clean rebuild is the right default.
- **Bump `step-security/harden-runner` to v2.19.4.** It was pinned to v2.14.0,
  which is affected by GHSA-46g3-37rh-v698, GHSA-g699-3x6g-wm3g and
  GHSA-cpmj-h4f6-r6pq. Re-pinned to the current release SHA with a matching
  comment.
- **Re-pin `sigstore/cosign-installer` to a tagged release.** It was pinned to
  an untagged commit (`7e0881f`, between v2.3.0 and v2.4.0) whose comment
  claimed `# v2.3.0` — Dependabot can't track an untagged pin and the comment
  was misleading. Re-pinned to the current release **v4.1.2**.
- **Correct hash-pin version comments** to match the tags the SHAs actually
  resolve to, and add a small **`.github/zizmor.yml`** disabling cosmetic
  pedantic-only rules so future scans stay focused on substantive findings.

## Note for reviewer

The `cosign-installer` re-pin crosses major versions (v2 → v4.1.2), so the
action installs a newer `cosign`. Please confirm that's compatible with the
release flow; if you'd prefer a more conservative bump, the pin/comment are easy
to adjust.

## Test plan

- `zizmor .github/` — clean after these changes.
- `actionlint` — the workflow still parses with no errors.

Refs: PSEC-923