### PR TITLE
fix(ci): add Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# See GitHub's documentation for more information on this file:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,7 @@
 rules:
+  dependabot-cooldown:
+    config:
+      days: 3
   # Cosmetic pedantic-only findings — suppressed across the campaign.
   anonymous-definition:
     disable: true


### PR DESCRIPTION
A small follow-up to the recent GitHub Actions hardening. The workflows pin all
external actions to commit SHAs, but the repo had no `dependabot.yml` — so those
pins (including the freshly re-pinned `cosign-installer` and `harden-runner`)
had no automated freshness mechanism and would drift out of date silently.

## What this changes

- **`.github/dependabot.yml`** — weekly update coverage for the `github-actions`
  and `gomod` ecosystems, with a 3-day cooldown so brand-new releases settle
  before a bump PR opens.
- **`.github/zizmor.yml`** — declare the matching `dependabot-cooldown` threshold
  (`days: 3`) so zizmor treats the configured cooldown as sufficient.

## Test plan

- `zizmor .github/` — clean after the change.

Refs: PSEC-923